### PR TITLE
Modified mib.rb regex in #.import_supported to allow newer libsmi

### DIFF
--- a/lib/snmp/mib.rb
+++ b/lib/snmp/mib.rb
@@ -112,7 +112,7 @@ module SNMP
       # known version of the tool is available.
       #
       def import_supported?
-        `smidump --version` =~ /^smidump 0.4/  && $? == 0
+        `smidump --version` =~ /^smidump 0.[45]/  && $? == 0
       end
 
       ##


### PR DESCRIPTION
Simple modification to import_supported? method to allow for version 4 or 5 of libsmi